### PR TITLE
Add `-stdlib=libc++` when `CXX` is unspecified

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ elif sys.platform == 'darwin':
 	libraries = []
 	extra_compile_args = [
 		'-std=c++0x',
-		'-stdlib=libc++',
 		'-Wno-deprecated-register',
 		'-Wno-#warnings']
 	extra_link_args = []
@@ -59,6 +58,7 @@ elif sys.platform == 'darwin':
 		os.environ['CC'] = 'clang++'
 	if 'CXX' not in os.environ:
 		os.environ['CXX'] = 'clang++'
+		extra_compile_args.append('-stdlib=libc++')
 	if 'MACOSX_DEPLOYMENT_TARGET' not in os.environ:
 		os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.7'
 


### PR DESCRIPTION
Fixes https://github.com/lucastheis/cmt/issues/25

This argument is not permissible with `gcc`. Also if a custom compiler like `icc` or a non-system provided copy of `clang` is used, this flag will also not work. In other words, only with the macOS provided `clang` can we safely add the `-stdlib=libc++` flag. If users are changing the compiler to one that for some reason can take this flag, they can just as well set it themselves. Hence we only set when `CXX` is not specified.