### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
     - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - "3.5"
     - "3.6"
 install:
+    - python -m pip install -U pip
     - pip install --only-binary=":all:" numpy scipy
     - cd code/liblbfgs
     - ./autogen.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
     - "3.5"
     - "3.6"
 install:
+    - pip install numpy scipy
     - cd code/liblbfgs
     - ./autogen.sh
     - ./configure --enable-sse2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
     - "3.5"
     - "3.6"
 install:
-    - pip install numpy scipy
+    - pip install --only-binary=":all:" numpy scipy
     - cd code/liblbfgs
     - ./autogen.sh
     - ./configure --enable-sse2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
     - "2.7"
+    - "3.5"
+    - "3.6"
 virtualenv:
   system_site_packages: true
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ python:
     - "2.7"
     - "3.5"
     - "3.6"
-before_install:
-    - sudo apt-get -qq install python-numpy python-scipy
 install:
     - cd code/liblbfgs
     - ./autogen.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ python:
     - "2.7"
     - "3.5"
     - "3.6"
-virtualenv:
-  system_site_packages: true
 before_install:
     - sudo apt-get -qq install python-numpy python-scipy
 install:

--- a/code/cmt/python/src/module.cpp
+++ b/code/cmt/python/src/module.cpp
@@ -762,7 +762,7 @@ static PyGetSetDef PatchModel_getset[] = {
 };
 
 static PyMethodDef PatchModel_methods[] = {
-	{"loglikelihood", (PyCFunction)PatchModel_loglikelihood, METH_KEYWORDS, 0},
+	{"loglikelihood", (PyCFunction)PatchModel_loglikelihood, METH_VARARGS | METH_KEYWORDS, 0},
 	{"input_mask", (PyCFunction)PatchModel_input_mask, METH_VARARGS, 0},
 	{"output_mask", (PyCFunction)PatchModel_output_mask, METH_VARARGS, 0},
 	{"input_indices", (PyCFunction)PatchModel_input_indices, 0, 0},
@@ -825,9 +825,9 @@ static PyGetSetDef PatchMCBM_getset[] = {
 };
 
 static PyMethodDef PatchMCBM_methods[] = {
-	{"initialize", (PyCFunction)PatchMCBM_initialize, METH_KEYWORDS, PatchMCBM_initialize_doc},
-	{"train", (PyCFunction)PatchMCBM_train, METH_KEYWORDS, PatchMCBM_train_doc},
-	{"preconditioner", (PyCFunction)PatchMCBM_preconditioner, METH_VARARGS, 0},
+	{"initialize", (PyCFunction)PatchMCBM_initialize, METH_VARARGS | METH_KEYWORDS, PatchMCBM_initialize_doc},
+	{"train", (PyCFunction)PatchMCBM_train, METH_VARARGS | METH_KEYWORDS, PatchMCBM_train_doc},
+	{"preconditioner", (PyCFunction)PatchMCBM_preconditioner, METH_VARARGS | METH_VARARGS, 0},
 	{"__reduce__", (PyCFunction)PatchMCBM_reduce, METH_NOARGS, PatchMCBM_reduce_doc},
 	{"__setstate__", (PyCFunction)PatchMCBM_setstate, METH_VARARGS, PatchMCBM_setstate_doc},
 	{0}
@@ -889,8 +889,8 @@ static PyGetSetDef PatchMCGSM_getset[] = {
 };
 
 static PyMethodDef PatchMCGSM_methods[] = {
-	{"initialize", (PyCFunction)PatchMCGSM_initialize, METH_KEYWORDS, PatchMCGSM_initialize_doc},
-	{"train", (PyCFunction)PatchMCGSM_train, METH_KEYWORDS, PatchMCGSM_train_doc},
+	{"initialize", (PyCFunction)PatchMCGSM_initialize, METH_VARARGS | METH_KEYWORDS, PatchMCGSM_initialize_doc},
+	{"train", (PyCFunction)PatchMCGSM_train, METH_VARARGS | METH_KEYWORDS, PatchMCGSM_train_doc},
 	{"preconditioner", (PyCFunction)PatchMCGSM_preconditioner, METH_VARARGS, 0},
 	{"__reduce__", (PyCFunction)PatchMCGSM_reduce, METH_NOARGS, PatchMCGSM_reduce_doc},
 	{"__setstate__", (PyCFunction)PatchMCGSM_setstate, METH_VARARGS, PatchMCGSM_setstate_doc},
@@ -1124,8 +1124,8 @@ static PyGetSetDef FVBN_getset[] = {
 };
 
 static PyMethodDef FVBN_methods[] = {
-	{"initialize", (PyCFunction)FVBN_initialize, METH_KEYWORDS, FVBN_initialize_doc},
-	{"train", (PyCFunction)FVBN_train, METH_KEYWORDS, FVBN_train_doc},
+	{"initialize", (PyCFunction)FVBN_initialize, METH_VARARGS | METH_KEYWORDS, FVBN_initialize_doc},
+	{"train", (PyCFunction)FVBN_train, METH_VARARGS | METH_KEYWORDS, FVBN_train_doc},
 	{"preconditioner", (PyCFunction)FVBN_preconditioner, METH_VARARGS, 0},
 	{"__reduce__", (PyCFunction)FVBN_reduce, METH_NOARGS, FVBN_reduce_doc},
 	{"__setstate__", (PyCFunction)FVBN_setstate, METH_VARARGS, FVBN_setstate_doc},

--- a/code/cmt/python/src/module.cpp
+++ b/code/cmt/python/src/module.cpp
@@ -765,7 +765,7 @@ static PyMethodDef PatchModel_methods[] = {
 	{"loglikelihood", (PyCFunction)PatchModel_loglikelihood, METH_VARARGS | METH_KEYWORDS, 0},
 	{"input_mask", (PyCFunction)PatchModel_input_mask, METH_VARARGS, 0},
 	{"output_mask", (PyCFunction)PatchModel_output_mask, METH_VARARGS, 0},
-	{"input_indices", (PyCFunction)PatchModel_input_indices, 0, 0},
+	{"input_indices", (PyCFunction)PatchModel_input_indices, METH_VARARGS, 0},
 	{0}
 };
 

--- a/code/cmt/python/src/pyutils.cpp
+++ b/code/cmt/python/src/pyutils.cpp
@@ -378,7 +378,11 @@ Regularizer PyObject_ToRegularizer(PyObject* regularizer) {
 		Regularizer::Norm norm = Regularizer::L2;
 
 		if(r_norm) {
+			if(PyUnicode_Check(r_norm))
+				r_norm = PyUnicode_AsASCIIString(r_norm);
+
 			if(PyString_Size(r_norm) != 2)
+				PyErr_Clear();
 				throw Exception("Regularizer norm should be 'L1' or 'L2'.");
 
 			switch(PyString_AsString(r_norm)[1]) {

--- a/code/cmt/python/src/pyutils.cpp
+++ b/code/cmt/python/src/pyutils.cpp
@@ -16,6 +16,7 @@ using std::make_pair;
 	#define PyInt_FromLong PyLong_FromLong
 	#define PyInt_AsLong PyLong_AsLong
 	#define PyInt_Check PyLong_Check
+	#define PyString_Check PyBytes_Check
 	#define PyString_Size PyBytes_Size
 	#define PyString_AsString PyBytes_AsString
 #endif
@@ -381,11 +382,18 @@ Regularizer PyObject_ToRegularizer(PyObject* regularizer) {
 			if(PyUnicode_Check(r_norm))
 				r_norm = PyUnicode_AsASCIIString(r_norm);
 
-			if(PyString_Size(r_norm) != 2)
+			if((r_norm == NULL) || (!PyString_Check(r_norm)) || (PyString_Size(r_norm) != 2)) {
 				PyErr_Clear();
 				throw Exception("Regularizer norm should be 'L1' or 'L2'.");
+			}
 
-			switch(PyString_AsString(r_norm)[1]) {
+			char* r_norm_str = PyString_AsString(r_norm);
+			if(r_norm_str == NULL) {
+				PyErr_Clear();
+				throw Exception("Regularizer norm should be 'L1' or 'L2'.");
+			}
+
+			switch(r_norm_str[1]) {
 				default:
 					throw Exception("Regularizer norm should be 'L1' or 'L2'.");
 

--- a/code/cmt/python/tests/fvbn_test.py
+++ b/code/cmt/python/tests/fvbn_test.py
@@ -18,8 +18,8 @@ class Tests(unittest.TestCase):
 
 		model = FVBN(8, 8, xmask, ymask)
 
-		self.assertLess(max(abs(model.input_mask() - xmask)), 1e-8)
-		self.assertLess(max(abs(model.output_mask() - ymask)), 1e-8)
+		self.assertLess(max(abs(model.input_mask() ^ xmask)), 1e-8)
+		self.assertLess(max(abs(model.output_mask() ^ ymask)), 1e-8)
 
 		for i in range(8):
 			for j in range(8):

--- a/code/cmt/python/tests/fvbn_test.py
+++ b/code/cmt/python/tests/fvbn_test.py
@@ -67,11 +67,11 @@ class Tests(unittest.TestCase):
 		tmp_file = mkstemp()[1]
 
 		# store model
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'model': model0}, handle)
 
 		# load model
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			model1 = load(handle)['model']
 
 		# make sure parameters haven't changed

--- a/code/cmt/python/tests/glm_test.py
+++ b/code/cmt/python/tests/glm_test.py
@@ -168,11 +168,11 @@ class Tests(unittest.TestCase):
 		model0.bias = randn()
 
 		# store model
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'model': model0}, handle)
 
 		# load model
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			model1 = load(handle)['model']
 
 		# make sure parameters haven't changed

--- a/code/cmt/python/tests/gsm_test.py
+++ b/code/cmt/python/tests/gsm_test.py
@@ -86,11 +86,11 @@ class Tests(unittest.TestCase):
 		tmp_file = mkstemp()[1]
 
 		# store model
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'model': model0}, handle)
 
 		# load model
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			model1 = load(handle)['model']
 
 		# make sure parameters haven't changed

--- a/code/cmt/python/tests/mcbm_test.py
+++ b/code/cmt/python/tests/mcbm_test.py
@@ -178,8 +178,8 @@ class Tests(unittest.TestCase):
 
 		model = PatchMCBM(8, 8, xmask, ymask, model=MCBM(sum(xmask), 1))
 
-		self.assertLess(max(abs(model.input_mask() - xmask)), 1e-8)
-		self.assertLess(max(abs(model.output_mask() - ymask)), 1e-8)
+		self.assertLess(max(abs(model.input_mask() ^ xmask)), 1e-8)
+		self.assertLess(max(abs(model.output_mask() ^ ymask)), 1e-8)
 
 		for i in range(8):
 			for j in range(8):
@@ -192,8 +192,8 @@ class Tests(unittest.TestCase):
 
 		model = PatchMCBM(rows, cols, xmask, ymask, order, MCBM(sum(xmask), 1))
 
-		self.assertLess(max(abs(model.input_mask() - xmask)), 1e-8)
-		self.assertLess(max(abs(model.output_mask() - ymask)), 1e-8)
+		self.assertLess(max(abs(model.input_mask() ^ xmask)), 1e-8)
+		self.assertLess(max(abs(model.output_mask() ^ ymask)), 1e-8)
 
 		for i in range(rows):
 			for j in range(cols):
@@ -203,8 +203,8 @@ class Tests(unittest.TestCase):
 		model0 = PatchMCBM(rows, cols, max_pcs=3)
 		model1 = PatchMCBM(rows, cols, model0.input_mask(), model0.output_mask(), model0.order)
 
-		self.assertLess(max(abs(model0.input_mask() - model1.input_mask())), 1e-8)
-		self.assertLess(max(abs(model0.output_mask() - model1.output_mask())), 1e-8)
+		self.assertLess(max(abs(model0.input_mask() ^ model1.input_mask())), 1e-8)
+		self.assertLess(max(abs(model0.output_mask() ^ model1.output_mask())), 1e-8)
 		self.assertLess(max(abs(asarray(model0.order) - asarray(model1.order))), 1e-8)
 
 		# test computation of input masks
@@ -213,7 +213,7 @@ class Tests(unittest.TestCase):
 		i, j = model0.order[0]
 		input_mask = model.input_mask(i, j)
 		for i, j in model.order[1:]:
-			self.assertEqual(sum(model.input_mask(i, j) - input_mask), 1)
+			self.assertEqual(sum(model.input_mask(i, j) ^ input_mask), 1)
 			input_mask = model.input_mask(i, j)
 
 
@@ -371,8 +371,8 @@ class Tests(unittest.TestCase):
 		self.assertEqual(model0.rows, model1.rows)
 		self.assertEqual(model0.cols, model1.cols)
 		self.assertLess(max(abs(asarray(model1.order) - asarray(model0.order))), 1e-20)
-		self.assertLess(max(abs(model0.input_mask() - model1.input_mask())), 1e-20)
-		self.assertLess(max(abs(model0.output_mask() - model1.output_mask())), 1e-20)
+		self.assertLess(max(abs(model0.input_mask() ^ model1.input_mask())), 1e-20)
+		self.assertLess(max(abs(model0.output_mask() ^ model1.output_mask())), 1e-20)
 
 		for i in range(model0.rows):
 			for j in range(model0.cols):

--- a/code/cmt/python/tests/mcbm_test.py
+++ b/code/cmt/python/tests/mcbm_test.py
@@ -149,11 +149,11 @@ class Tests(unittest.TestCase):
 		tmp_file = mkstemp()[1]
 
 		# store model
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'mcbm': mcbm0}, handle)
 
 		# load model
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			mcbm1 = load(handle)['mcbm']
 
 		# make sure parameters haven't changed
@@ -329,11 +329,11 @@ class Tests(unittest.TestCase):
 		tmp_file = mkstemp()[1]
 
 		# store model
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'model': model0}, handle)
 
 		# load model
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			model1 = load(handle)['model']
 
 		# make sure parameters haven't changed
@@ -360,11 +360,11 @@ class Tests(unittest.TestCase):
 		tmp_file = mkstemp()[1]
 
 		# store model
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'model': model0}, handle)
 
 		# load model
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			model1 = load(handle)['model']
 
 		# make sure parameters haven't changed
@@ -389,11 +389,11 @@ class Tests(unittest.TestCase):
 		logLik = mean(model0.loglikelihood(samples))
 
 		# store model
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'model': model0}, handle)
 
 		# load model
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			model1 = load(handle)['model']
 
 		self.assertAlmostEqual(mean(model1.loglikelihood(samples)), logLik)
@@ -404,11 +404,11 @@ class Tests(unittest.TestCase):
 		model0 = PatchMCBM(rows, cols, xmask, ymask, order)
 
 		# store model
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'model': model0}, handle)
 
 		# load model
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			model1 = load(handle)['model']
 
 		for i in range(rows):

--- a/code/cmt/python/tests/mcgsm_test.py
+++ b/code/cmt/python/tests/mcgsm_test.py
@@ -174,9 +174,9 @@ class Tests(unittest.TestCase):
 
 		# generated samples should have the same distribution
 		for i in range(mogsm.dim):
-			self.assertTrue(ks_2samp(mogsm_samples[i], mcgsm_samples[0]) > 0.0001)
-			self.assertTrue(ks_2samp(mogsm_samples[i], mcgsm_samples[1]) > 0.0001)
-			self.assertTrue(ks_2samp(mogsm_samples[i], mcgsm_samples[2]) > 0.0001)
+			self.assertTrue(ks_2samp(mogsm_samples[i], mcgsm_samples[0]).pvalue > 0.0001)
+			self.assertTrue(ks_2samp(mogsm_samples[i], mcgsm_samples[1]).pvalue > 0.0001)
+			self.assertTrue(ks_2samp(mogsm_samples[i], mcgsm_samples[2]).pvalue > 0.0001)
 
 		posterior = mcgsm.posterior(input, mcgsm_samples)
 

--- a/code/cmt/python/tests/mcgsm_test.py
+++ b/code/cmt/python/tests/mcgsm_test.py
@@ -385,11 +385,11 @@ class Tests(unittest.TestCase):
 		tmp_file = mkstemp()[1]
 
 		# store model
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'mcgsm': mcgsm0}, handle)
 
 		# load model
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			mcgsm1 = load(handle)['mcgsm']
 
 		# make sure parameters haven't changed

--- a/code/cmt/python/tests/mcgsm_test.py
+++ b/code/cmt/python/tests/mcgsm_test.py
@@ -127,7 +127,7 @@ class Tests(unittest.TestCase):
 				})
 
 		# test callback
-		self.assertTrue(range(cb_iter, max_iter + 1, cb_iter) == count)
+		self.assertTrue(list(range(cb_iter, max_iter + 1, cb_iter)) == count)
 
 
 

--- a/code/cmt/python/tests/mcgsm_test.py
+++ b/code/cmt/python/tests/mcgsm_test.py
@@ -421,8 +421,8 @@ class Tests(unittest.TestCase):
 
 		model = PatchMCGSM(8, 8, xmask, ymask, model=MCGSM(sum(xmask), 1))
 
-		self.assertLess(max(abs(model.input_mask() - xmask)), 1e-8)
-		self.assertLess(max(abs(model.output_mask() - ymask)), 1e-8)
+		self.assertLess(max(abs(model.input_mask() ^ xmask)), 1e-8)
+		self.assertLess(max(abs(model.output_mask() ^ ymask)), 1e-8)
 
 		for i in range(8):
 			for j in range(8):
@@ -435,8 +435,8 @@ class Tests(unittest.TestCase):
 
 		model = PatchMCGSM(rows, cols, xmask, ymask, order, MCGSM(sum(xmask), 1))
 
-		self.assertLess(max(abs(model.input_mask() - xmask)), 1e-8)
-		self.assertLess(max(abs(model.output_mask() - ymask)), 1e-8)
+		self.assertLess(max(abs(model.input_mask() ^ xmask)), 1e-8)
+		self.assertLess(max(abs(model.output_mask() ^ ymask)), 1e-8)
 
 		for i in range(rows):
 			for j in range(cols):
@@ -446,8 +446,8 @@ class Tests(unittest.TestCase):
 		model0 = PatchMCGSM(rows, cols, max_pcs=3)
 		model1 = PatchMCGSM(rows, cols, model0.input_mask(), model0.output_mask(), model0.order)
 
-		self.assertLess(max(abs(model0.input_mask() - model1.input_mask())), 1e-8)
-		self.assertLess(max(abs(model0.output_mask() - model1.output_mask())), 1e-8)
+		self.assertLess(max(abs(model0.input_mask() ^ model1.input_mask())), 1e-8)
+		self.assertLess(max(abs(model0.output_mask() ^ model1.output_mask())), 1e-8)
 		self.assertLess(max(abs(asarray(model0.order) - asarray(model1.order))), 1e-8)
 
 		# test computation of input masks
@@ -456,7 +456,7 @@ class Tests(unittest.TestCase):
 		i, j = model0.order[0]
 		input_mask = model.input_mask(i, j)
 		for i, j in model.order[1:]:
-			self.assertEqual(sum(model.input_mask(i, j) - input_mask), 1)
+			self.assertEqual(sum(model.input_mask(i, j) ^ input_mask), 1)
 			input_mask = model.input_mask(i, j)
 
 

--- a/code/cmt/python/tests/mixture_test.py
+++ b/code/cmt/python/tests/mixture_test.py
@@ -65,11 +65,11 @@ class Test(unittest.TestCase):
 			tmp_file = mkstemp()[1]
 
 			# store model
-			with open(tmp_file, 'w') as handle:
+			with open(tmp_file, 'wb') as handle:
 				dump({'model': model0}, handle)
 
 			# load model
-			with open(tmp_file) as handle:
+			with open(tmp_file, 'rb') as handle:
 				model1 = load(handle)['model']
 
 			# make sure parameters haven't changed

--- a/code/cmt/python/tests/mlr_test.py
+++ b/code/cmt/python/tests/mlr_test.py
@@ -73,11 +73,11 @@ class Tests(unittest.TestCase):
 		model0.biases = randn(*model0.biases.shape)
 
 		# store model
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'model': model0}, handle)
 
 		# load model
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			model1 = load(handle)['model']
 
 		# make sure parameters haven't changed

--- a/code/cmt/python/tests/nonlinear_test.py
+++ b/code/cmt/python/tests/nonlinear_test.py
@@ -24,10 +24,10 @@ class Tests(unittest.TestCase):
 
 		f0 = LogisticFunction()
 
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'f': f0}, handle)
 
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			f1 = load(handle)['f']
 
 		x = randn(100)
@@ -50,10 +50,10 @@ class Tests(unittest.TestCase):
 
 		f0 = ExponentialFunction()
 
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'f': f0}, handle)
 
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			f1 = load(handle)['f']
 
 		x = randn(100)
@@ -78,11 +78,11 @@ class Tests(unittest.TestCase):
 		f0 = HistogramNonlinearity(randn(1, 100), rand(1, 100), 10)
 
 		# store model
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'f': f0}, handle)
 
 		# load model
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			f1 = load(handle)['f']
 
 		x = randn(1, 100)
@@ -118,11 +118,11 @@ class Tests(unittest.TestCase):
 		f0 = BlobNonlinearity(4, 0.1)
 
 		# store model
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'f': f0}, handle)
 
 		# load model
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			f1 = load(handle)['f']
 
 		x = randn(1, 100)
@@ -158,11 +158,11 @@ class Tests(unittest.TestCase):
 		f0 = TanhBlobNonlinearity(4, 0.1)
 
 		# store model
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'f': f0}, handle)
 
 		# load model
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			f1 = load(handle)['f']
 
 		x = randn(1, 100)

--- a/code/cmt/python/tests/preconditioner_test.py
+++ b/code/cmt/python/tests/preconditioner_test.py
@@ -144,11 +144,11 @@ class Tests(unittest.TestCase):
 		tmp_file = mkstemp()[1]
 
 		# store transformation
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'pre': pre0}, handle)
 
 		# load transformation
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			pre1 = load(handle)['pre']
 
 		X, Y = randn(5, 100), randn(2, 100)
@@ -179,11 +179,11 @@ class Tests(unittest.TestCase):
 		tmp_file = mkstemp()[1]
 
 		# store transformation
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'pre': pre0}, handle)
 
 		# load transformation
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			pre1 = load(handle)['pre']
 
 		X, Y = randn(5, 100), randn(3, 100)
@@ -241,11 +241,11 @@ class Tests(unittest.TestCase):
 		tmp_file = mkstemp()[1]
 
 		# store transformation
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'wt': wt0}, handle)
 
 		# load transformation
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			wt1 = load(handle)['wt']
 
 		X, Y = randn(5, 100), randn(2, 100)
@@ -287,11 +287,11 @@ class Tests(unittest.TestCase):
 		tmp_file = mkstemp()[1]
 
 		# store transformation
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'wt': wt0}, handle)
 
 		# load transformation
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			wt1 = load(handle)['wt']
 
 		X, Y = randn(5, 100), randn(2, 100)
@@ -339,11 +339,11 @@ class Tests(unittest.TestCase):
 		tmp_file = mkstemp()[1]
 
 		# store transformation
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'wt': wt0}, handle)
 
 		# load transformation
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			wt1 = load(handle)['wt']
 
 		X, Y = randn(5, 100), randn(2, 100)
@@ -428,11 +428,11 @@ class Tests(unittest.TestCase):
 		tmp_file = mkstemp()[1]
 
 		# store transformation
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'wt': wt0}, handle)
 
 		# load transformation
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			wt1 = load(handle)['wt']
 
 		X, Y = randn(5, 100), randn(2, 100)
@@ -467,11 +467,11 @@ class Tests(unittest.TestCase):
 		tmp_file = mkstemp()[1]
 
 		# store transformation
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'pre': pre0}, handle)
 
 		# load transformation
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			pre1 = load(handle)['pre']
 
 		# make sure linear transformation hasn't changed

--- a/code/cmt/python/tests/speed.py
+++ b/code/cmt/python/tests/speed.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 import socket
 
@@ -16,10 +18,10 @@ parser.add_argument('--repetitions', '-r', type=int, default=2)
 args = parser.parse_args(sys.argv[1:])
 
 ###
-print socket.gethostname()
-print datetime.now()
-print args
-print
+print(socket.gethostname())
+print(datetime.now())
+print(args)
+print()
 
 ###
 data = randn(args.dim_in, args.num_data), randn(args.dim_out, args.num_data)
@@ -32,24 +34,24 @@ model = MCGSM(
 	num_scales=6)
 
 ###
-print 'model.loglikelihood'
+print('model.loglikelihood')
 t = time()
 for r in range(args.repetitions):
 	model.loglikelihood(*data)
-print '{0:12.8f} seconds'.format((time() - t) / float(args.repetitions))
-print
+print('{0:12.8f} seconds'.format((time() - t) / float(args.repetitions)))
+print()
 
 ###
-print 'model._check_performance'
+print('model._check_performance')
 for batch_size in [1000, 2000, 5000]:
 	t = model._check_performance(*data, repetitions=args.repetitions, parameters={'batch_size': batch_size})
-	print '{0:12.8f} seconds ({1})'.format(t, batch_size)
-print
+	print('{0:12.8f} seconds ({1})'.format(t, batch_size))
+print()
 
 ###
-print 'model.posterior'
+print('model.posterior')
 t = time()
 for r in range(args.repetitions):
 	model.posterior(*data)
-print '{0:12.8f} seconds'.format((time() - t) / float(args.repetitions))
-print
+print('{0:12.8f} seconds'.format((time() - t) / float(args.repetitions)))
+print()

--- a/code/cmt/python/tests/stm_test.py
+++ b/code/cmt/python/tests/stm_test.py
@@ -283,11 +283,11 @@ class Tests(unittest.TestCase):
 		tmp_file = mkstemp()[1]
 
 		# store model
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'stm': stm0}, handle)
 
 		# load model
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			stm1 = load(handle)['stm']
 
 		# make sure parameters haven't changed

--- a/code/cmt/python/tests/univariate_test.py
+++ b/code/cmt/python/tests/univariate_test.py
@@ -25,10 +25,10 @@ class Tests(unittest.TestCase):
 
 		p0 = Bernoulli(.3)
 
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'p': p0}, handle)
 
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			p1 = load(handle)['p']
 
 		x = p0.sample(100)
@@ -78,10 +78,10 @@ class Tests(unittest.TestCase):
 
 		p0 = Poisson(2.5)
 
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'p': p0}, handle)
 
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			p1 = load(handle)['p']
 
 		x = p0.sample(100)
@@ -126,10 +126,10 @@ class Tests(unittest.TestCase):
 
 		p0 = Binomial(13, .76)
 
-		with open(tmp_file, 'w') as handle:
+		with open(tmp_file, 'wb') as handle:
 			dump({'p': p0}, handle)
 
-		with open(tmp_file) as handle:
+		with open(tmp_file, 'rb') as handle:
 			p1 = load(handle)['p']
 
 		x = p0.sample(100)

--- a/tutorials/images.py
+++ b/tutorials/images.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 """
 Trains an MCGSM on a single grayscale image.
 """
@@ -64,8 +66,8 @@ def main(argv):
 		})
 
 	# evaluate model
-	print 'Average log-likelihood: {0:.4f} [bit/px]'.format(
-			-model.evaluate(data_test[0], data_test[1], pre))
+	print('Average log-likelihood: {0:.4f} [bit/px]'.format(
+			-model.evaluate(data_test[0], data_test[1], pre)))
 
 	# synthesize a new image
 	img_sample = sample_image(img, model, input_mask, output_mask, pre)


### PR DESCRIPTION
* Add Python 3.5 and 3.6 to the Travis CI matrix.
* Install NumPy and SciPy with wheels on Travis CI.
* Update pip on Travis CI (particularly for Python 2.7).
* Open files as binary when working with pickle.
* Use `print` function with Python for 2/3 compatibility.
* Workaround a bug in Python 3's C API. ( https://bugs.python.org/issue11587 )
* Make various fixes to the code for Python 3 compatibility.
* Fix registration of the `input_indices` function.
* Use `^` with NumPy bool arrays instead of `-`.
* Handle unicode in regularizer.
* Handle Python errors thrown in regularizer.
* Workaround a SciPy incompatibility between Python 2/3. ( https://github.com/scipy/scipy/issues/6099 )
* Cherry picked the fix from PR ( https://github.com/lucastheis/cmt/pull/30 ).