### PR TITLE
Register `adjust_gradient` in `Preconditioner`

### DIFF
--- a/code/cmt/python/src/module.cpp
+++ b/code/cmt/python/src/module.cpp
@@ -1755,6 +1755,7 @@ static PyGetSetDef Preconditioner_getset[] = {
 static PyMethodDef Preconditioner_methods[] = {
 	{"inverse", (PyCFunction)Preconditioner_inverse, METH_VARARGS | METH_KEYWORDS, Preconditioner_inverse_doc},
 	{"logjacobian", (PyCFunction)Preconditioner_logjacobian, METH_VARARGS | METH_KEYWORDS, Preconditioner_logjacobian_doc},
+	{"adjust_gradient", (PyCFunction)Preconditioner_adjust_gradient, METH_VARARGS | METH_KEYWORDS, Preconditioner_adjust_gradient_doc},
 	{0}
 };
 


### PR DESCRIPTION
Fixes https://github.com/lucastheis/cmt/issues/29

Appears the `adjust_gradient` method was not registered in the `Preconditioner` methods when it was added. This properly registers it so that it can be used in Python.